### PR TITLE
Remove Zip file from image to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN apk add --no-cache wget ttf-dejavu && \
   adduser -D -u 1000 irpf
 
 RUN wget http://downloadirpf.receita.fazenda.gov.br/irpf/2019/irpf/arquivos/IRPF2019-1.2.zip -O irpf.zip && \
-  unzip irpf.zip -d /opt/
+  unzip irpf.zip -d /opt/ && \
+  rm irpf.zip
 WORKDIR /opt/IRPF2019
 
 USER irpf


### PR DESCRIPTION
The Zip file is not necessary in the image, can be removed to make
the image size smaller.