### PR TITLE
Make it work in older docker-compose versions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '2'
 services:
   irpf:
     container_name: irpf


### PR DESCRIPTION
Since this file only uses features that were already available in
docker-compose version 2, it is safe to decrease the minimum required
version so older installations can also make use of this.